### PR TITLE
chore: add conventional commit rules and gate deploy on feat/fix

### DIFF
--- a/.github/workflows/trigger-build.yaml
+++ b/.github/workflows/trigger-build.yaml
@@ -5,6 +5,9 @@ on:
 jobs:
   trigger:
     runs-on: ubuntu-latest
+    if: >-
+      startsWith(github.event.head_commit.message, 'feat:') ||
+      startsWith(github.event.head_commit.message, 'fix:')
     steps:
       - uses: actions/checkout@v4
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,3 +41,13 @@ Common overflow culprits and fixes:
 - Compress hero images to JPEG at 80% quality using `sips` (built-in macOS tool)
 - Target size: under 300KB for hero images
 - Command: `sips -s format jpeg -s formatOptions 80 input.png --out hero.jpg`
+
+## Commits and PRs
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/). Allowed prefixes:
+
+- `feat:` — new feature or blog post (triggers publish)
+- `fix:` — bug fix (triggers publish)
+- `chore:` — maintenance, config, dependency updates
+
+PR titles must use the same format (e.g. `feat: add post on terminal multiplexers`). Merging a `feat:` or `fix:` PR to `publish` triggers a deploy.


### PR DESCRIPTION
## Summary
- Add conventional commit guidelines (feat, fix, chore) to CLAUDE.md
- Gate the cr-engine build workflow to only trigger on `feat:` or `fix:` commits

## Test plan
- [ ] Verify `chore:` merge does not trigger cr-engine build
- [ ] Verify `feat:` or `fix:` merge triggers build as before