### PR TITLE
fix: rewrite Dream article as case study with ideation

### DIFF
--- a/claude-code-dream-memory-consolidation/claim.json
+++ b/claude-code-dream-memory-consolidation/claim.json
@@ -1,7 +1,7 @@
 {
     "title": "Dream: How Claude Code Consolidates Memory While You Sleep",
     "pubDate": "2026-04-07",
-    "description": "A source-level deep dive into Claude Code's Dream system — the background memory consolidation agent that reviews your recent sessions, merges scattered facts, resolves contradictions, and prunes stale entries. Covers the gate hierarchy, file-based CAS locking, the 4-phase consolidation prompt, and the forked subagent architecture.",
+    "description": "A case study from exploring Claude Code's source: Dream is a background agent that consolidates memory the way sleep consolidates learning. We map its gate cascade, file-based CAS lock, and sandboxed forked agent — then explore where these patterns lead for autonomous AI tooling.",
     "tags": [
         "claude-code",
         "memory",

--- a/claude-code-dream-memory-consolidation/index.md
+++ b/claude-code-dream-memory-consolidation/index.md
@@ -1,30 +1,40 @@
-**TL;DR** Claude Code has a background agent called Dream that periodically reviews your recent sessions, merges scattered memory entries, resolves contradictions, and prunes stale facts. It runs as a forked subagent while you work, uses a file-based compare-and-swap lock for multi-process safety, and gates execution behind a five-level cascade designed to cost nearly nothing on most turns.
+**TL;DR** While exploring Claude Code's source, we found a system called Dream: a background agent that consolidates memory the way biological sleep consolidates learning. It is a case study in building reliable background AI agents, and its patterns, gate cascades, file-based CAS locks, sandboxed forked subagents, point toward a future where AI tools maintain long-term knowledge autonomously.
 
 ---
 
-## The Problem: Ephemeral Intelligence
+## What We Found
 
-Every Claude Code session generates insight about your codebase, preferences, and debugging patterns. The memory system captures individual facts as they appear via per-turn extraction. But turn-level extraction is reactive: it saves facts one at a time without cross-session perspective.
+While mapping Claude Code's 1300+ module codebase file by file, we stumbled on a directory that stopped us: `services/autoDream/`. About 500 lines of production TypeScript implementing something the codebase calls "Dream."
 
-Over time, this creates **memory drift**. Individual facts accumulate without organization. A preference saved in session 3 might be contradicted by session 7. Related facts scatter across separate files. The `MEMORY.md` index grows bloated.
+The name is not decorative. Dream is a **background memory consolidation agent** that mirrors biological sleep consolidation. When you are not actively prompting, it reviews your recent sessions, merges scattered memory entries, resolves contradictions, and prunes stale facts. The user sees nothing but a quiet "Improved N memories" message.
 
-Dream solves this by stepping back periodically to review all recent sessions holistically. The name mirrors biological sleep consolidation: short-term memories are merged into long-term knowledge during downtime.
+This is not documentation of an API. This is a case study of what we found in the source, what design patterns it reveals, and where those patterns lead.
 
 ---
 
-## What Dream Actually Is
+## The Core Insight: AI Agents Need Downtime Too
 
-Dream is a background memory consolidation agent. After you accumulate enough sessions (default: 5 over 24 hours), it fires automatically as a forked subagent. It reviews recent conversation history, reorganizes your memory directory, and surfaces a quiet "Improved N memories" notification when done.
+Every Claude Code session generates insight about your codebase, preferences, and debugging patterns. The memory system captures these as individual facts via per-turn extraction. But reactive extraction creates a problem familiar to anyone who has taken notes in a meeting: the notes accumulate, contradict each other, and nobody goes back to organize them.
 
-The feature lives in `services/autoDream/` (~500 lines) plus UI components in `tasks/DreamTask/`.
+Dream is the "going back to organize" step. It fires automatically when enough new experience has accumulated (5 sessions over 24 hours) and performs what the source calls "memory surgery": merging related facts, resolving contradictions, pruning stale entries, and keeping the memory index within budget.
+
+The biological metaphor runs deep. Dream:
+
+- Runs during downtime, never blocking active work
+- Reviews recent episodes holistically
+- Consolidates ephemeral signal into durable storage
+- Prunes and compresses aggressively
+- Fires periodically, not continuously
+
+This is the first AI coding tool we have seen that implements offline knowledge management as a first-class background process.
 
 ![Dream Lifecycle](dream-lifecycle.svg)
 
 ---
 
-## The Gate Hierarchy
+## Case Study: The Gate Cascade
 
-Dream checks whether to fire **after every turn**, but the check is designed to cost nearly nothing in the common case. Gates are ordered cheapest first. The moment one fails, execution returns:
+The first engineering challenge: Dream fires after *every* turn, but most turns should cost nothing. The solution is a five-gate cascade ordered by cost:
 
 | Gate | Cost |
 |------|------|
@@ -34,149 +44,67 @@ Dream checks whether to fire **after every turn**, but the check is designed to 
 | 5+ sessions touched? | `readdir` |
 | Lock available? | `stat` + `read` |
 
-The typical per-turn cost is **one flag check and one `stat()`** before returning. The expensive session scan only runs when the time gate has already passed.
+The typical turn pays **one flag check and one `stat()`** before returning. The expensive session scan only runs when cheaper gates have already passed.
 
-### The Scan Throttle
+**What makes this worth studying:** This cascade pattern is general-purpose. Any background agent that triggers on user activity needs to answer "should I fire?" cheaply. The principle is to order checks by cost and bail at the first failure. The Dream implementation shows how to layer in-memory checks, filesystem checks, and cross-process coordination into a single cascade where the common case is nearly free.
 
-A subtle edge case: when the time gate passes (>24h) but the session gate fails (not enough sessions), the lock `mtime` has not advanced. So the time gate passes again on the *next* turn, and the next.
+### A Subtle Edge Case
 
-Without mitigation, every turn would trigger a directory scan. The scan throttle remembers the last scan time in a closure and short-circuits if under 10 minutes:
+When the time gate passes (>24h) but the session gate fails (not enough sessions yet), the lock `mtime` has not advanced. So the time gate passes again on the *next* turn. Without mitigation, every turn triggers a directory scan.
 
-```
-sinceScan = Date.now() - lastScanAt
-if sinceScan < 10min:
-  return  // skip scan
-lastScanAt = Date.now()
-```
+The solution: a closure-scoped scan throttle that remembers the last scan time and short-circuits if under 10 minutes have elapsed. This variable lives inside the `initAutoDream()` closure rather than at module scope, so tests get fresh state by calling `initAutoDream()` in `beforeEach` without module reload.
 
-This is closure-scoped (inside `initAutoDream()`) rather than module-scoped, so tests get a fresh closure via `initAutoDream()` in `beforeEach` without module reload.
-
-### Feature Gate
-
-```
-isGateOpen():
-  if KAIROS mode   → false
-  if remote mode    → false
-  if !autoMemory    → false
-  return autoDreamEnabled
-```
-
-KAIROS mode is excluded because it implements its own `/dream` skill through a different trigger model (nightly distillation of daily logs).
+This is the kind of detail that separates production systems from prototypes: the interaction between independent gates creates emergent behavior that needs its own mitigation.
 
 ---
 
-## Configuration
+## Case Study: The File-Based CAS Lock
 
-Dream uses a two-tier model: user settings override server-side defaults.
-
-**Enable/disable** is resolved as:
+Dream needs multi-process safety. Multiple CLI sessions might try to consolidate simultaneously. The solution is elegant: **a single file where the mtime is the timestamp and the body is the PID**.
 
 ```
-autoDreamEnabled in settings.json?
-  → use that value (hard override)
-else
-  → check GrowthBook tengu_onyx_plover
+.consolidate-lock
+  mtime → when last consolidated
+  body  → PID of current holder (or empty)
 ```
 
-**Scheduling thresholds** (`minHours`, `minSessions`) come from the same GrowthBook flag with defensive per-field validation. Every value is type-checked, finite-checked, and positive-checked. A negative `minHours` would mean "always fire" and burn API tokens.
+Most systems use separate lock and timestamp files. Here, filesystem metadata carries scheduling info while file content carries concurrency info. One file, two orthogonal concerns.
 
----
+### Compare-and-Swap Protocol
 
-## The Lock: A File That Is Its Own Timestamp
-
-Dream needs to prevent two things: concurrent consolidations across processes and re-triggering too soon. Both are solved with a single file:
-
-```
-~/.claude/projects/<hash>/memory/
-  .consolidate-lock
-    mtime → when last consolidated
-    body  → PID of current holder
-```
-
-Most systems use separate lock and timestamp files. Here, the filesystem metadata carries scheduling info while file content carries concurrency info.
-
-### Compare-and-Swap Acquisition
-
-`tryAcquireConsolidationLock()` implements a CAS pattern:
+Acquisition follows a CAS pattern:
 
 ```
 1. stat() + readFile() in parallel
 2. If held by live process → blocked
 3. If dead PID or stale → reclaim
 4. Write our PID
-5. Re-read to verify we won the race
-6. If PID mismatch → lost race, exit
+5. Re-read to verify we won race
+6. If PID changed → lost, exit
 ```
 
-Two processes reclaiming simultaneously: both write their PID. The last writer wins. The loser re-reads, sees a different PID, and returns `null`.
+Two processes reclaiming simultaneously: both write. Last writer wins. The loser re-reads, sees a different PID, returns `null`.
 
-### Rollback
+### Rollback: Rewinding Time
 
-On fork failure or user kill, the lock `mtime` must rewind so the time gate passes again:
+On failure, the lock `mtime` must rewind so the time gate passes again:
 
 ```
 rollbackConsolidationLock(priorMtime):
   if priorMtime == 0:
-    unlink(lock)       // restore no-file
+    unlink(lock)        // no-file state
   else:
     writeFile(lock, '') // clear PID
     utimes(lock, prior) // rewind mtime
 ```
 
-The PID body is cleared because our process is still alive. Without clearing, we would look like we still hold the lock.
+**Why this pattern matters:** File-based CAS is underrated for single-machine coordination. No database, no IPC, no daemon process. `stat()` is one of the cheapest syscalls. `utimes()` can atomically rewind time for rollback. The file content carries orthogonal state. This pattern works anywhere you need lightweight cross-process coordination without infrastructure dependencies.
 
 ---
 
-## The Consolidation Prompt
+## Case Study: The Sandboxed Forked Agent
 
-The dream agent follows four phases, structured to minimize wasted context:
-
-### Phase 1: Orient
-
-Survey the memory directory before making changes. `ls` the directory, read `MEMORY.md`, skim existing topic files. This prevents creating duplicates because the agent did not know a file existed.
-
-### Phase 2: Gather Recent Signal
-
-Sources in priority order:
-
-1. **Daily logs** (highest signal-to-noise)
-2. **Drifted memories** (facts contradicting current code)
-3. **Transcript search** (narrow `grep` only)
-
-The prompt explicitly constrains:
-
-> "Don't exhaustively read transcripts. Look only for things you already suspect matter."
-
-Session transcripts are large JSONL files. Reading them fully would blow through context limits. The agent uses targeted grep:
-
-```bash
-grep -rn "<term>" transcripts/ \
-  --include="*.jsonl" | tail -50
-```
-
-### Phase 3: Consolidate
-
-Write or update memory files. Key rules:
-
-- Merge into existing files, do not duplicate
-- Convert relative dates to absolute
-- Delete contradicted facts at the source
-
-### Phase 4: Prune and Index
-
-`MEMORY.md` must stay under 200 lines and ~25KB. Each entry is one line:
-
-```
-- [Title](file.md) -- one-line hook
-```
-
-Remove stale pointers, demote verbose entries, add new memories, resolve conflicts.
-
----
-
-## The Forked Agent
-
-Dream does not spawn a separate process. It runs as a **forked subagent** in the same process with isolated state:
+Dream does not spawn a separate process. It runs as a **forked subagent**: an isolated instance of the same Claude query loop, running in the same process with its own context, tool permissions, and abort controller.
 
 ```
 runForkedAgent({
@@ -190,22 +118,7 @@ runForkedAgent({
 })
 ```
 
-### Isolation
-
-The fork gets:
-
-- Fresh file state cache (mutations do not propagate back)
-- Independent `AbortController` (linked to parent but separately killable)
-- Fresh skill/memory tracking
-- No-op mutation callbacks for parent state
-
-### Prompt Cache Sharing
-
-The key optimization. The Anthropic API caches system prompts, tools, and message prefixes. If the fork sends the same prefix as the parent, it gets a cache hit.
-
-`cacheSafeParams` captures the parent's system prompt, tools, and context messages. As long as these are byte-identical, the fork benefits from cached prompt processing. This is why `cacheSafeParams` is explicitly passed rather than reconstructed: any difference would invalidate the cache key.
-
-### Tool Sandbox
+### The Sandbox
 
 | Tool | Permission |
 |------|------------|
@@ -214,96 +127,46 @@ The key optimization. The Anthropic API caches system prompts, tools, and messag
 | Edit, Write | Memory directory only |
 | Everything else | Denied |
 
-The sandbox prevents the dream agent from modifying project code while allowing it to read whatever context it needs. Denied tool attempts fire analytics (`tengu_auto_mem_tool_denied`).
+The dream agent can read your entire codebase and transcripts but can only write to the memory directory. Bash is restricted to `ls`, `grep`, `cat`, `stat`, and similar read-only commands via `tool.isReadOnly()` checks.
 
-### Transcript Isolation
+### Prompt Cache Sharing
 
-`skipTranscript: true` keeps dream's internal reasoning out of the session transcript. The only user-visible artifact is the "Improved N memories" inline system message.
+The key optimization. The Anthropic API caches system prompts and message prefixes. If the fork sends the exact same prefix as the parent, it gets a cache hit.
+
+`cacheSafeParams` captures the parent's system prompt, tools, and context messages and passes them explicitly rather than reconstructing them. Any byte difference would invalidate the cache key.
+
+**Why this pattern matters:** Sandboxed forked agents are a powerful primitive. You get the full capability of the LLM query loop with controlled tool access, isolated state, and prompt cache sharing. Dream uses this for memory consolidation, but the same pattern could power code review agents, documentation agents, or any background task that needs LLM reasoning without risking side effects.
 
 ---
 
-## Task System: Making the Invisible Visible
+## The 4-Phase Consolidation Prompt
 
-Before task integration, dream was completely invisible. The task system surfaces it through three levels:
+The dream agent's work is structured into four phases, each minimizing wasted context:
 
-**Footer pill** — A simple `dreaming` label in the status bar. Minimal indicator.
+**Phase 1 (Orient):** Survey the memory directory. Read `MEMORY.md`. Skim topic files. This prevents duplicates.
 
-**Background tasks dialog** (Shift+Down):
+**Phase 2 (Gather):** Collect recent signal from daily logs, drifted memories, and narrow transcript searches. The prompt explicitly constrains:
 
-```
-Memory consolidation
-  reviewing 5 sessions       running
-```
+> "Don't exhaustively read transcripts. Look only for things you already suspect matter."
 
-Phase flips to "updating" when the first Edit/Write tool use is detected.
+This is critical. Transcripts are large JSONL files. The agent uses targeted `grep`:
 
-**Detail view** (Enter on task) — Shows the last 6 turns from a 30-turn rolling buffer. Each turn displays agent reasoning and tool use count. The `x` key kills the dream.
-
-### State Shape
-
-```typescript
-type DreamTaskState = {
-  type: 'dream'
-  phase: 'starting' | 'updating'
-  sessionsReviewing: number
-  filesTouched: string[]
-  turns: DreamTurn[]  // max 30
-  abortController?: AbortController
-  priorMtime: number  // for rollback
-}
+```bash
+grep -rn "<term>" transcripts/ \
+  --include="*.jsonl" | tail -50
 ```
 
-The `priorMtime` is stashed at registration so the kill handler can rewind the lock without re-reading it.
+**Phase 3 (Consolidate):** Write or update memory files. Merge into existing files, convert relative dates to absolute, delete contradicted facts at the source.
 
-### Kill Handler
+**Phase 4 (Prune):** Keep `MEMORY.md` under 200 lines and ~25KB. Remove stale pointers, demote verbose entries, resolve conflicts between files.
 
-Kill is idempotent: if the task is already terminal, state is unchanged and rollback is skipped. This prevents double-rollback if the kill races with natural completion.
-
----
-
-## Error Handling
-
-Three failure modes, each handled differently:
-
-**User kill** — `abortController.signal.aborted` is true. Exit silently. `DreamTask.kill` already aborted the controller, rolled back the lock, and set `status: 'killed'`.
-
-**Fork error** — Mark task failed, roll back the lock (so time gate passes on next turn), fire analytics. The scan throttle provides 10-minute natural backoff.
-
-**Process crash** — Lock file has a dead PID. Next process reclaims after 1 hour (`HOLDER_STALE_MS`). No manual intervention needed.
+**What makes this worth studying:** The 4-phase structure is a pattern for any agent that needs to modify a knowledge base. Orient before acting (prevent duplicates), gather selectively (do not exhaust context), write incrementally (merge over create), and prune afterward (maintain budget constraints). These phases map naturally to any knowledge maintenance task.
 
 ---
 
-## Auto-Dream vs Manual /dream
+## Crash Safety: Defense in Depth
 
-| Aspect | Auto | Manual |
-|--------|------|--------|
-| Trigger | 24h + 5 sessions | User runs `/dream` |
-| Execution | Background fork | Foreground |
-| Bash | Read-only | Full access |
-| Transcript | Skipped | Recorded |
-| Lock | Full CAS cycle | Stamps mtime only |
-
-Both share `buildConsolidationPrompt()` for the 4-phase structure. Auto-dream appends read-only Bash constraints via an `extra` parameter.
-
-When manual `/dream` runs, it calls `recordConsolidation()` to advance the lock `mtime`, preventing auto-dream from redundantly firing.
-
----
-
-## Three Memory Mechanisms
-
-Dream is one of three mechanisms:
-
-**Turn-level extraction** (`extractMemories`) runs after every turn. Fast and reactive but lacks cross-session perspective. Creates the memory drift that Dream corrects.
-
-**Auto-Dream** runs periodically (24h + 5 sessions). Reviews sessions holistically. Merges, deduplicates, resolves contradictions, prunes. Slow but high-quality.
-
-**Daily logs** (KAIROS mode) writes append-only daily logs as events happen. The manual `/dream` distills these into structured memories. This is the KAIROS-specific path.
-
-Turn-level extraction is note-taking during a meeting. Dream is reviewing your notes that evening.
-
----
-
-## Crash Safety
+The source reveals careful thinking about failure modes:
 
 | Scenario | Behavior |
 |----------|----------|
@@ -315,36 +178,48 @@ Turn-level extraction is note-taking during a meeting. Dream is reviewing your n
 | Memory dir missing | mkdir -p, created lazily |
 | GrowthBook returns garbage | Defaults: 24h, 5 sessions |
 
+Every failure path has a recovery mechanism. The worst case is a delayed retry, never data corruption. The scan throttle doubles as backoff after failure: a failed dream rewinds the lock mtime, which would cause immediate re-triggering, but the 10-minute throttle provides natural spacing.
+
 ---
 
-## Design Decisions
+## Where This Pattern Leads
 
-**Why mtime instead of a database?** `stat()` is one of the cheapest filesystem operations. `utimes()` can rewind atomically for rollback. The file content (PID) carries orthogonal concurrency info. No extra persistence layer needed.
+Dream is currently limited to memory consolidation. But the underlying primitives, gate cascades, CAS locks, sandboxed forked agents, prompt-structured knowledge work, are general-purpose. Here is where we see this heading:
 
-**Why closure-scoped state?** `lastSessionScanAt` lives inside the `initAutoDream()` closure. Tests get fresh state by calling `initAutoDream()` in `beforeEach` without module reload or global cleanup.
+### Background Code Review
 
-**Why only two UI phases?** The dream agent follows a 4-phase prompt, but parsing the phases would require fragile text matching. Instead, the phase flips on the first Edit/Write tool use. Robust and prompt-change-proof.
+A dream-like agent could periodically review recent commits against project conventions, architectural decisions, and known patterns. Instead of "Improved N memories," it would surface "Found 3 consistency issues in recent changes." The same gate cascade ensures it only fires when meaningful work has accumulated.
 
-**Why read-only Bash?** The agent needs to scan transcripts and codebase but must never modify project code. Rather than blocking Bash entirely (losing `grep` and `ls`), the permission system checks `tool.isReadOnly()` per invocation.
+### Proactive Documentation
 
-**Why fire-and-forget?** Dream can take minutes. Blocking the user is unacceptable. Dream's output is not needed until a future session. Failure is recoverable via lock rollback. The user can monitor and kill via the tasks dialog.
+An agent that watches for code changes and updates relevant documentation. The sandbox pattern (read everything, write only to `docs/`) keeps it safe. The 4-phase prompt structure (orient on existing docs, gather code changes, update, prune) maps directly.
 
-**Why does scan throttle double as backoff?** After failure, lock rollback rewinds mtime. The time gate would pass immediately on the next turn. The 10-minute scan throttle provides natural backoff without a separate retry counter.
+### Cross-Session Learning
+
+Dream currently consolidates memory from a fixed project directory. Extend it to cross-project patterns: "This user always structures error handling this way," "This user prefers composition over inheritance." The gate hierarchy would add a project-count gate, and the consolidation prompt would look for transferable patterns.
+
+### Multi-Agent Coordination
+
+The CAS lock pattern could coordinate not just concurrent dreams but any set of background agents. An agent registry file (like the lock file but with an array of agent states) could prevent conflicting background work: "do not run the documentation agent while the refactoring agent is active."
+
+### Graduated Autonomy
+
+Dream currently runs fire-and-forget with a kill switch. A natural evolution: graduated autonomy levels. Level 1 (current): consolidate silently. Level 2: consolidate and propose changes that need approval. Level 3: take corrective action (fix a stale import, update a test). Each level uses the same forked agent with progressively wider tool permissions.
 
 ---
 
 ## Key Takeaways
 
-1. **Gate cascade** makes the per-turn cost nearly zero: one flag check and one `stat()` in the common case.
+1. **Background AI agents are viable today.** Dream proves that an LLM-powered agent can run reliably in the background with predictable costs and safe failure modes.
 
-2. **File-based CAS lock** solves both scheduling (mtime) and concurrency (PID body) with a single file.
+2. **Gate cascades make background agents cheap.** By ordering checks from cheapest to most expensive, the per-turn cost is nearly zero in the common case.
 
-3. **Forked subagent** runs in the same process with isolated state and shared prompt cache.
+3. **File-based CAS is underrated.** A single file with mtime-as-timestamp and content-as-PID solves both scheduling and concurrency without infrastructure dependencies.
 
-4. **4-phase prompt** structures the agent's work: orient, gather, consolidate, prune.
+4. **Sandboxed forked agents are a powerful primitive.** Full LLM reasoning with controlled tool access, isolated state, and shared prompt cache.
 
-5. **Sandbox** restricts the agent to read-only Bash and memory-directory-only writes.
+5. **The 4-phase prompt structure generalizes.** Orient, gather, consolidate, prune maps to any knowledge maintenance task.
 
-6. **Crash recovery** is automatic: dead PIDs are reclaimed after 1 hour with no manual intervention.
+6. **Crash recovery should be automatic.** Dead PIDs are reclaimed, locks roll back, and the worst case is a delayed retry. No manual intervention needed.
 
-Dream is a case study in building reliable background agents. The gate hierarchy, CAS locking, and rollback mechanics are patterns applicable well beyond memory consolidation.
+Dream is small (500 lines) but architecturally significant. It demonstrates that AI tools can maintain persistent, evolving knowledge about their users and codebases, not just react to the current conversation. That is a meaningful step toward AI systems that genuinely learn from experience.


### PR DESCRIPTION
## Summary
- Reframes the Dream article from documentation to case study
- Each technical section now has a "Why this matters" analysis
- Adds "Where This Pattern Leads" section with forward-looking ideation: background code review, proactive docs, cross-session learning, multi-agent coordination, graduated autonomy
- Framing: "what we found exploring the source" not "here is the spec"

## Test plan
- [ ] Article reads as discovery and analysis, not documentation
- [ ] All code blocks under 50 chars for mobile